### PR TITLE
squid:S1213 - The members of an interface declaration or class should…

### DIFF
--- a/app/src/main/java/com/sigseg/android/io/RandomAccessFileInputStream.java
+++ b/app/src/main/java/com/sigseg/android/io/RandomAccessFileInputStream.java
@@ -29,7 +29,17 @@ public class RandomAccessFileInputStream extends InputStream {
         } catch(IOException e) { Log.e(TAG, e.getMessage()); }
         Log.d(TAG,"opened, len = "+fileLength);
     }
-    
+
+    public RandomAccessFileInputStream(File file)
+            throws FileNotFoundException {
+        this(file, DEFAULT_BUFFER_SIZE);
+    }
+
+    public RandomAccessFileInputStream(String filename)
+            throws FileNotFoundException {
+        this(new File(filename), DEFAULT_BUFFER_SIZE);
+    }
+
     public int available() {
         long pos=0;
         int res;
@@ -40,17 +50,6 @@ public class RandomAccessFileInputStream extends InputStream {
         Log.d(TAG,"available "+res);
         return res;
     }
-    
-    public RandomAccessFileInputStream(File file)
-    throws FileNotFoundException {
-        this(file, DEFAULT_BUFFER_SIZE);
-    }
-
-    public RandomAccessFileInputStream(String filename)
-    throws FileNotFoundException {
-        this(new File(filename), DEFAULT_BUFFER_SIZE);
-    }
-
 
     @Override
     public int read() throws IOException {

--- a/app/src/main/java/com/sigseg/android/map/ImageSurfaceView.java
+++ b/app/src/main/java/com/sigseg/android/map/ImageSurfaceView.java
@@ -31,6 +31,31 @@ public class ImageSurfaceView extends SurfaceView implements SurfaceHolder.Callb
 
     private DrawThread drawThread;
 
+    Point fling_viewOrigin = new Point();
+    Point fling_viewSize = new Point();
+    Point fling_sceneSize = new Point();
+
+    //endregion
+
+    //region SurfaceHolder.Callback constructors
+    public ImageSurfaceView(Context context) {
+        super(context);
+        touch = new Touch(context);
+        init(context);
+    }
+
+    public ImageSurfaceView(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+        touch = new Touch(context);
+        init(context);
+    }
+
+    public ImageSurfaceView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        touch = new Touch(context);
+        init(context);
+    }
+
     //region getters and setters
     public void getViewport(Point p){
         scene.getViewport().getOrigin(p);
@@ -74,27 +99,7 @@ public class ImageSurfaceView extends SurfaceView implements SurfaceHolder.Callb
         }
         return super.onTouchEvent(me);
     }
-    //endregion
 
-    //region SurfaceHolder.Callback constructors
-    public ImageSurfaceView(Context context) {
-        super(context);
-        touch = new Touch(context);
-        init(context);
-    }
-    
-    public ImageSurfaceView(Context context, AttributeSet attrs, int defStyle) {
-        super(context, attrs, defStyle);
-        touch = new Touch(context);
-        init(context);
-    }
-
-    public ImageSurfaceView(Context context, AttributeSet attrs) {
-        super(context, attrs);
-        touch = new Touch(context);
-        init(context);
-    }
-    
     private void init(Context context){
         gestureDectector = new GestureDetector(context,this);
         getHolder().addCallback(this);
@@ -196,12 +201,13 @@ public class ImageSurfaceView extends SurfaceView implements SurfaceHolder.Callb
         private SurfaceHolder surfaceHolder;
 
         private boolean running = false;
-        public void setRunning(boolean value){ running = value; }
-        
+
         public DrawThread(SurfaceHolder surfaceHolder){
             this.surfaceHolder = surfaceHolder;
         }
-        
+
+        public void setRunning(boolean value){ running = value; }
+
         @Override
         public void run() {
             Canvas c;
@@ -267,10 +273,7 @@ public class ImageSurfaceView extends SurfaceView implements SurfaceHolder.Callb
             }
             touchThread = null;
         }
-        
-        Point fling_viewOrigin = new Point();
-        Point fling_viewSize = new Point();
-        Point fling_sceneSize = new Point();
+
         boolean fling( MotionEvent e1, MotionEvent e2, float velocityX, float velocityY){
             scene.getViewport().getOrigin(fling_viewOrigin);
             scene.getViewport().getSize(fling_viewSize);
@@ -345,8 +348,7 @@ public class ImageSurfaceView extends SurfaceView implements SurfaceHolder.Callb
         class TouchThread extends Thread {
             final Touch touch;
             boolean running = false;
-            void setRunning(boolean value){ running = value; }
-            
+
             TouchThread(Touch touch){ this.touch = touch; }
             @Override
             public void run() {
@@ -379,6 +381,9 @@ public class ImageSurfaceView extends SurfaceView implements SurfaceHolder.Callb
                     }
                 }
             }
+
+            void setRunning(boolean value){ running = value; }
+
         }
     }
     //endregion

--- a/app/src/main/java/com/sigseg/android/view/InputStreamScene.java
+++ b/app/src/main/java/com/sigseg/android/view/InputStreamScene.java
@@ -27,6 +27,15 @@ public class InputStreamScene extends Scene {
     private BitmapRegionDecoder decoder;
     private Bitmap sampleBitmap;
 
+    private static Paint red = new Paint();
+
+    private Rect calculatedCacheWindowRect = new Rect();
+
+    static{
+        red.setColor(Color.RED);
+        red.setStrokeWidth(5L);
+    }
+
     static {
         options.inPreferredConfig = Bitmap.Config.RGB_565;
     }
@@ -57,11 +66,6 @@ public class InputStreamScene extends Scene {
         return bitmap;
     }
 
-    private static Paint red = new Paint();
-    static{
-        red.setColor(Color.RED);
-        red.setStrokeWidth(5L);
-    }
     @Override
     protected void drawSampleRectIntoBitmap(Bitmap bitmap, Rect rectOfSample) {
         if (bitmap!=null){
@@ -88,7 +92,6 @@ public class InputStreamScene extends Scene {
 //        return viewportRect;
 //    }
 
-    private Rect calculatedCacheWindowRect = new Rect();
     @Override
     protected Rect calculateCacheWindow(Rect viewportRect) {
         long bytesToUse = Runtime.getRuntime().maxMemory() * percent / 100;

--- a/app/src/main/java/com/sigseg/android/view/Scene.java
+++ b/app/src/main/java/com/sigseg/android/view/Scene.java
@@ -43,7 +43,10 @@ public abstract class Scene {
     private final Viewport viewport = new Viewport();
     /** The cache */
     private final Cache cache = new Cache();
-    
+
+    /** Our load from disk thread */
+    CacheThread cacheThread;
+
     //region [gs]etSceneSize
     /** Set the size of the scene */
     public void setSceneSize(int width, int height){
@@ -330,16 +333,17 @@ public abstract class Scene {
         Bitmap bitmapRef = null;
         CacheState state = CacheState.UNINITIALIZED;
 
+        final Rect srcRect = new Rect(0,0,0,0);
+        final Rect dstRect = new Rect(0,0,0,0);
+        final Point dstSize = new Point();
+
         void setState(CacheState newState){
             if (Debug.isDebuggerConnected())
                 Log.i(TAG,String.format("cacheState old=%s new=%s",state.toString(),newState.toString()));
             state = newState;
         }
         CacheState getState(){ return state; }
-        
-        /** Our load from disk thread */
-        CacheThread cacheThread;
-        
+
         void start(){
             if (cacheThread!=null){
                 cacheThread.setRunning(false);
@@ -448,10 +452,7 @@ public abstract class Scene {
                 }
             }
         }
-        final Rect srcRect = new Rect(0,0,0,0);
-        final Rect dstRect = new Rect(0,0,0,0);
-        final Point dstSize = new Point();
-        
+
         void loadSampleIntoViewport(){
             if (getState()!=CacheState.UNINITIALIZED){
                 synchronized(viewport){
@@ -485,10 +486,11 @@ public abstract class Scene {
     class CacheThread extends Thread {
         final Cache cache;
         boolean running = false;
-        void setRunning(boolean value){ running = value; }
-        
+
         CacheThread(Cache cache){ this.cache = cache; }
-        
+
+        void setRunning(boolean value){ running = value; }
+
         @Override
         public void run() {
             running=true;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1213

Please let me know if you have any questions.

M-Ezzat
