### PR TITLE
squid:S2039 - Member variable visibility should be specified

### DIFF
--- a/app/src/main/java/com/sigseg/android/io/RandomAccessFileInputStream.java
+++ b/app/src/main/java/com/sigseg/android/io/RandomAccessFileInputStream.java
@@ -16,10 +16,10 @@ import android.util.Log;
 public class RandomAccessFileInputStream extends InputStream {
 
     public static  int DEFAULT_BUFFER_SIZE = 16 * 1024;
-    RandomAccessFile fp;
-    long markPos=-1;
-    long fileLength = -1;
-        String TAG="WorldMapActivityRAIFS";
+    private RandomAccessFile fp;
+    private long markPos = -1;
+    private long fileLength = -1;
+    private String TAG = "WorldMapActivityRAIFS";
     
     public RandomAccessFileInputStream(File file, int bufferSize)
             throws FileNotFoundException {

--- a/app/src/main/java/com/sigseg/android/map/ImageSurfaceView.java
+++ b/app/src/main/java/com/sigseg/android/map/ImageSurfaceView.java
@@ -31,9 +31,9 @@ public class ImageSurfaceView extends SurfaceView implements SurfaceHolder.Callb
 
     private DrawThread drawThread;
 
-    Point fling_viewOrigin = new Point();
-    Point fling_viewSize = new Point();
-    Point fling_sceneSize = new Point();
+    private Point fling_viewOrigin = new Point();
+    private Point fling_viewSize = new Point();
+    private Point fling_sceneSize = new Point();
 
     //endregion
 
@@ -238,15 +238,15 @@ public class ImageSurfaceView extends SurfaceView implements SurfaceHolder.Callb
 
     enum TouchState {UNTOUCHED,IN_TOUCH,START_FLING,IN_FLING};
     class Touch {
-        TouchState state = TouchState.UNTOUCHED;
+        private TouchState state = TouchState.UNTOUCHED;
         /** Where on the view did we initially touch */
-        final Point viewDown = new Point(0,0);
+        private final Point viewDown = new Point(0,0);
         /** What was the coordinates of the viewport origin? */
-        final Point viewportOriginAtDown = new Point(0,0);
-        
-        final Scroller scroller;
-        
-        TouchThread touchThread;
+        private final Point viewportOriginAtDown = new Point(0,0);
+
+        private final Scroller scroller;
+
+        private TouchThread touchThread;
         
         Touch(Context context){
             scroller = new Scroller(context);
@@ -346,8 +346,8 @@ public class ImageSurfaceView extends SurfaceView implements SurfaceHolder.Callb
         }
         
         class TouchThread extends Thread {
-            final Touch touch;
-            boolean running = false;
+            private final Touch touch;
+            private boolean running = false;
 
             TouchThread(Touch touch){ this.touch = touch; }
             @Override

--- a/app/src/main/java/com/sigseg/android/view/Scene.java
+++ b/app/src/main/java/com/sigseg/android/view/Scene.java
@@ -45,7 +45,7 @@ public abstract class Scene {
     private final Cache cache = new Cache();
 
     /** Our load from disk thread */
-    CacheThread cacheThread;
+    private CacheThread cacheThread;
 
     //region [gs]etSceneSize
     /** Set the size of the scene */
@@ -173,10 +173,10 @@ public abstract class Scene {
 
     public class Viewport {
         /** The bitmap of the current viewport */
-        Bitmap bitmap = null;
+        private Bitmap bitmap = null;
         /** A Rect that defines where the Viewport is within the scene */
-        final Rect window = new Rect(0,0,0,0);
-        float zoom = 1.0f;
+        private final Rect window = new Rect(0,0,0,0);
+        private float zoom = 1.0f;
 
         public void setOrigin(int x, int y){
             synchronized(this){
@@ -328,14 +328,14 @@ public abstract class Scene {
      */
     private class Cache {
         /** A Rect that defines where the Cache is within the scene */
-        final Rect window = new Rect(0,0,0,0);
+        private final Rect window = new Rect(0,0,0,0);
         /** The bitmap of the current cache */
-        Bitmap bitmapRef = null;
-        CacheState state = CacheState.UNINITIALIZED;
+        private Bitmap bitmapRef = null;
+        private CacheState state = CacheState.UNINITIALIZED;
 
-        final Rect srcRect = new Rect(0,0,0,0);
-        final Rect dstRect = new Rect(0,0,0,0);
-        final Point dstSize = new Point();
+        private final Rect srcRect = new Rect(0,0,0,0);
+        private final Rect dstRect = new Rect(0,0,0,0);
+        private final Point dstSize = new Point();
 
         void setState(CacheState newState){
             if (Debug.isDebuggerConnected())
@@ -484,8 +484,8 @@ public abstract class Scene {
      * {@link Scene#fillCache(Rect)}. 
      */
     class CacheThread extends Thread {
-        final Cache cache;
-        boolean running = false;
+        private final Cache cache;
+        private boolean running = false;
 
         CacheThread(Cache cache){ this.cache = cache; }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2039 - Member variable visibility should be specified

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2039

Please let me know if you have any questions.

M-Ezzat
