### PR TITLE
Multiple quality improvements - squid:SwitchLastCaseIsDefaultCheck, s…

### DIFF
--- a/app/src/main/java/com/sigseg/android/io/RandomAccessFileInputStream.java
+++ b/app/src/main/java/com/sigseg/android/io/RandomAccessFileInputStream.java
@@ -15,11 +15,11 @@ import android.util.Log;
 
 public class RandomAccessFileInputStream extends InputStream {
 
+    private static final String TAG = "WorldMapActivityRAIFS";
     public static  int DEFAULT_BUFFER_SIZE = 16 * 1024;
     private RandomAccessFile fp;
     private long markPos = -1;
     private long fileLength = -1;
-    private String TAG = "WorldMapActivityRAIFS";
     
     public RandomAccessFileInputStream(File file, int bufferSize)
             throws FileNotFoundException {

--- a/app/src/main/java/com/sigseg/android/map/ImageSurfaceView.java
+++ b/app/src/main/java/com/sigseg/android/map/ImageSurfaceView.java
@@ -27,13 +27,13 @@ public class ImageSurfaceView extends SurfaceView implements SurfaceHolder.Callb
     private final Touch touch;
     private GestureDetector gestureDectector;
     private ScaleGestureDetector scaleGestureDetector;
-    private long lastScaleTime = 0;
+    private long lastScaleTime;
 
     private DrawThread drawThread;
 
-    private Point fling_viewOrigin = new Point();
-    private Point fling_viewSize = new Point();
-    private Point fling_sceneSize = new Point();
+    private Point flingViewOrigin = new Point();
+    private Point flingViewSize = new Point();
+    private Point flingSceneSize = new Point();
 
     //endregion
 
@@ -96,6 +96,8 @@ public class ImageSurfaceView extends SurfaceView implements SurfaceHolder.Callb
                 return touch.move(me);
             case MotionEvent.ACTION_UP: return touch.up(me);
             case MotionEvent.ACTION_CANCEL: return touch.cancel(me);
+            default:
+                break;
         }
         return super.onTouchEvent(me);
     }
@@ -200,7 +202,7 @@ public class ImageSurfaceView extends SurfaceView implements SurfaceHolder.Callb
     class DrawThread extends Thread {
         private final SurfaceHolder surfaceHolder;
 
-        private boolean running = false;
+        private boolean running;
 
         public DrawThread(SurfaceHolder surfaceHolder){
             this.surfaceHolder = surfaceHolder;
@@ -275,22 +277,22 @@ public class ImageSurfaceView extends SurfaceView implements SurfaceHolder.Callb
         }
 
         boolean fling( MotionEvent e1, MotionEvent e2, float velocityX, float velocityY){
-            scene.getViewport().getOrigin(fling_viewOrigin);
-            scene.getViewport().getSize(fling_viewSize);
-            scene.getSceneSize(fling_sceneSize);
+            scene.getViewport().getOrigin(flingViewOrigin);
+            scene.getViewport().getSize(flingViewSize);
+            scene.getSceneSize(flingSceneSize);
 
             synchronized(this){
                 state = TouchState.START_FLING;
                 scene.setSuspend(true);
                 scroller.fling(
-                    fling_viewOrigin.x,
-                    fling_viewOrigin.y,
+                    flingViewOrigin.x,
+                    flingViewOrigin.y,
                     (int)-velocityX,
                     (int)-velocityY,
                     0, 
-                    fling_sceneSize.x-fling_viewSize.x, 
+                    flingSceneSize.x- flingViewSize.x, 
                     0,
-                    fling_sceneSize.y-fling_viewSize.y);
+                    flingSceneSize.y- flingViewSize.y);
                 touchThread.interrupt();
             }
 //            Log.d(TAG,String.format("scroller.fling(%d,%d,%d,%d,%d,%d,%d,%d)",
@@ -347,7 +349,7 @@ public class ImageSurfaceView extends SurfaceView implements SurfaceHolder.Callb
         
         class TouchThread extends Thread {
             private final Touch touch;
-            private boolean running = false;
+            private boolean running;
 
             TouchThread(Touch touch){ this.touch = touch; }
             @Override

--- a/app/src/main/java/com/sigseg/android/map/ImageViewerActivity.java
+++ b/app/src/main/java/com/sigseg/android/map/ImageViewerActivity.java
@@ -22,7 +22,7 @@ public class ImageViewerActivity extends Activity {
     private static final String KEY_FN = "FN";
     
     private ImageSurfaceView imageSurfaceView;
-    private String filename = null;
+    private String filename;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/java/com/sigseg/android/view/InputStreamScene.java
+++ b/app/src/main/java/com/sigseg/android/view/InputStreamScene.java
@@ -8,15 +8,14 @@ import android.util.Log;
 
 public class InputStreamScene extends Scene {
     private static final String TAG=InputStreamScene.class.getSimpleName();
-    
+    /** How many bytes does one pixel use? */
+    private static final int BYTES_PER_PIXEL = 4;
+
     private static final boolean DEBUG = false;
     private static final BitmapFactory.Options options = new BitmapFactory.Options();
 
     /** What is the downsample size for the sample image?  1=1/2, 2=1/4 3=1/8, etc */
     private static final int DOWN_SAMPLE_SHIFT = 2;
-
-    /** How many bytes does one pixel use? */
-    private final int BYTES_PER_PIXEL = 4;
 
     /** What percent of total memory should we use for the cache? The bigger the cache,
      * the longer it takes to read -- 1.2 secs for 25%, 600ms for 10%, 500ms for 5%.

--- a/app/src/main/java/com/sigseg/android/view/Scene.java
+++ b/app/src/main/java/com/sigseg/android/view/Scene.java
@@ -33,9 +33,9 @@ import android.util.Log;
  * actually return the necessary bitmaps.
  */
 public abstract class Scene {
-    private final String TAG = "Scene";
+    private static final String TAG = "Scene";
 
-    private final static int MINIMUM_PIXELS_IN_VIEW = 50;
+    private static final int MINIMUM_PIXELS_IN_VIEW = 50;
 
     /** The size of the Scene */
     private final Point size = new Point();
@@ -173,7 +173,7 @@ public abstract class Scene {
 
     public class Viewport {
         /** The bitmap of the current viewport */
-        private Bitmap bitmap = null;
+        private Bitmap bitmap;
         /** A Rect that defines where the Viewport is within the scene */
         private final Rect window = new Rect(0,0,0,0);
         private float zoom = 1.0f;
@@ -330,7 +330,7 @@ public abstract class Scene {
         /** A Rect that defines where the Cache is within the scene */
         private final Rect window = new Rect(0,0,0,0);
         /** The bitmap of the current cache */
-        private Bitmap bitmapRef = null;
+        private Bitmap bitmapRef;
         private CacheState state = CacheState.UNINITIALIZED;
 
         private final Rect srcRect = new Rect(0,0,0,0);
@@ -417,6 +417,8 @@ public abstract class Scene {
                         bitmap = bitmapRef;
                     }
                     break;
+                default:
+                    break;
                 }
             }
             if (bitmap==null)
@@ -485,7 +487,7 @@ public abstract class Scene {
      */
     class CacheThread extends Thread {
         private final Cache cache;
-        private boolean running = false;
+        private boolean running;
 
         CacheThread(Cache cache){ this.cache = cache; }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause
squid:S00116 - Field names should comply with a naming convention
squid:S3052 - Fields should not be initialized to default values

You can find more information about the issues here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:SwitchLastCaseIsDefaultCheck
https://dev.eclipse.org/sonar/coding_rules#q=squid:S00116
https://dev.eclipse.org/sonar/coding_rules#q=squid:S3052

Please let me know if you have any questions.

M-Ezzat
