### PR TITLE
Code cleanup - squid:S2142 - InterruptedException should not be ignored

### DIFF
--- a/app/src/main/java/com/sigseg/android/map/ImageSurfaceView.java
+++ b/app/src/main/java/com/sigseg/android/map/ImageSurfaceView.java
@@ -158,6 +158,7 @@ public class ImageSurfaceView extends SurfaceView implements SurfaceHolder.Callb
                 retry = false;
             } catch (InterruptedException e) {
                 // we will try it again and again...
+                Thread.currentThread().interrupt();
             }
         }
     }
@@ -215,7 +216,9 @@ public class ImageSurfaceView extends SurfaceView implements SurfaceHolder.Callb
                 try {
                     // Don't hog the entire CPU
                     Thread.sleep(5);
-                } catch (InterruptedException e) {}
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
                 c = null;
                 try {
                     c = surfaceHolder.lockCanvas();
@@ -269,6 +272,7 @@ public class ImageSurfaceView extends SurfaceView implements SurfaceHolder.Callb
                     retry = false;
                 } catch (InterruptedException e) {
                     // we will try it again and again...
+                    Thread.currentThread().interrupt();
                 }
             }
             touchThread = null;
@@ -357,7 +361,9 @@ public class ImageSurfaceView extends SurfaceView implements SurfaceHolder.Callb
                     while(touch.state!=TouchState.START_FLING && touch.state!=TouchState.IN_FLING){
                         try {
                             Thread.sleep(Integer.MAX_VALUE);
-                        } catch (InterruptedException e) {}
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
                         if (!running)
                             return;
                     }
@@ -375,7 +381,9 @@ public class ImageSurfaceView extends SurfaceView implements SurfaceHolder.Callb
                                 touch.state = TouchState.UNTOUCHED;
                                 try{
                                     Thread.sleep(5);
-                                } catch (InterruptedException e) {}
+                                } catch (InterruptedException e) {
+                                    Thread.currentThread().interrupt();
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/com/sigseg/android/view/Scene.java
+++ b/app/src/main/java/com/sigseg/android/view/Scene.java
@@ -366,6 +366,7 @@ public abstract class Scene {
                     retry = false;
                 } catch (InterruptedException e) {
                     // we will try it again and again...
+                    Thread.currentThread().interrupt();
                 }
             }
             cacheThread = null;
@@ -500,7 +501,9 @@ public abstract class Scene {
                     try {
                         // Sleep until we have something to do
                         Thread.sleep(Integer.MAX_VALUE);
-                    } catch (InterruptedException ignored) {}
+                    } catch (InterruptedException ignored) {
+                        Thread.currentThread().interrupt();
+                    }
                 if (!running)
                     return;
                 long start = System.currentTimeMillis();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2142 - "InterruptedException" should not be ignored

You can find more information about the issue here: https://sonarqube.com/coding_rules#rule_key=squid:S2142

Please let me know if you have any questions.

M-Ezzat
